### PR TITLE
Are solochains aligned with Polkadot's ethos welcomed here?

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,14 @@ and developed by an external team who wins the bid.
 ### Definition
 
 One is eligible as a member of the Polkadot EVM collective if one is involved in
-the development of a tool or a parachain that have EVM feature. This currently
+the development of a tool or a parachain/solochain that have EVM feature. This currently
 includes:
 
 * [Frontier](https://github.com/polkadot-evm/frontier)
 * [Rust-EVM](https://github.com/rust-ethereum/evm)
 * [Moonbeam](https://github.com/moonbeam-foundation/moonbeam)
 * [Astar](https://github.com/AstarNetwork/Astar)
+* [Edgeware (EdgeEVM)](https://github.com/edgeware-network/edgeware-node)
 * Please submit PRs to add another tool to this list.
 
 We currently only define two ranks, rank I and rank III. Rank I means a member


### PR DESCRIPTION
context: Edgeware after launching the mainnet in Feb 2020, included EdgeEVM in the runtime in early 2021. EdgeEVM's implementation utilises the Frontier in cherry-picked combination with tech developed by Moonbeam (evm-tracing, rpc and tx-pool). Edgeware DAO contributors have developed/ported several tools and protocols for EdgeEVM and can play a crucial role in shaping and evolution of the Polkadot EVM collective.