### PR TITLE
Add Acala

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ includes:
 * [Moonbeam](https://github.com/moonbeam-foundation/moonbeam)
 * [Astar](https://github.com/AstarNetwork/Astar)
 * [Edgeware (EdgeEVM)](https://github.com/edgeware-network/edgeware-node)
+* [Acala](https://github.com/AcalaNetwork/Acala)
 * Please submit PRs to add another tool to this list.
 
 We currently only define two ranks, rank I and rank III. Rank I means a member


### PR DESCRIPTION
Acala and Bodhi stack is an alternative EVM stack for Substrate chains other than Frontier